### PR TITLE
fix(security): update qs package to fix DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13016,9 +13016,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
Updates qs from 6.15.0 to 6.15.2 to resolve GHSA-q8mj-m7cp-5q26 - remotely triggerable DoS via qs.stringify with null/undefined entries in comma-format arrays.